### PR TITLE
named argument interface, don't rely on clownface methods, more options in load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"
 before_install:
   - npm install -g codecov
 script:

--- a/README.md
+++ b/README.md
@@ -32,11 +32,8 @@ registry.registerNodeLoader('http://example.com/Lolcode', loader)
 registry.registerLiteralLoader('http://example.com/LolcodeInline', loader)
 
 // somewhere else in code
-registry.load(
-  node,
-  context: {},
-  variables: new Map(),
-  basePath: process.cwd()
+registry.load(node, {
+  // some additional options
 })
 ```
 
@@ -48,13 +45,10 @@ A loader is a function which implements the following signature:
 
 ```typescript
 (
-  node: Node,
-  dataset: Dataset, 
+  node: { term, dataset, graph }, 
   {
-    context: Object, 
-    variables: Map, 
-    basePath: string,
-    loaderRegistry: LoaderRegistry
+    loaderRegistry: LoaderRegistry,
+    ...
   }
 ) => any
 ```

--- a/examples/ngc2392.js
+++ b/examples/ngc2392.js
@@ -1,6 +1,6 @@
 const cf = require('clownface')
 const namespace = require('@rdfjs/namespace')
-const rdf = require('rdf-ext')
+const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const LoaderRegistry = require('..')
 
 const ns = {
@@ -10,17 +10,17 @@ const ns = {
 }
 
 // Literal loader that simple converts the value of the Literal using parseInt
-function integerLoader (term) {
-  return parseInt(term.value)
+function integerLoader (node) {
+  return parseInt(node.term.value)
 }
 
 // Node loader that creates a nebular object (label, distance) using nested loaders
-async function nebulaLoader (term, dataset, { loaderRegistry }) {
-  const node = cf(dataset, term)
+async function nebulaLoader (node, { loaderRegistry }) {
+  const cfNode = cf(node)
 
   return {
-    label: node.out(ns.example.label).value,
-    distance: await loaderRegistry.load(node.out(ns.example.distance))
+    label: cfNode.out(ns.example.label).value,
+    distance: await loaderRegistry.load(cfNode.out(ns.example.distance))
   }
 }
 
@@ -33,7 +33,7 @@ async function main () {
   registry.registerNodeLoader(ns.example.Nebula, nebulaLoader)
 
   // create the quads for the nebular object
-  const ngc2392 = cf(rdf.dataset(), ns.example('ngc/2392'))
+  const ngc2392 = cf({ term: ns.example('ngc/2392'), dataset: rdf.dataset() })
   ngc2392.addOut(ns.rdf.type, ns.example.Nebula)
   ngc2392.addOut(ns.example.label, rdf.literal('Clownface Nebula'))
   ngc2392.addOut(ns.example.distance, rdf.literal('2870', ns.xsd.integer))

--- a/package.json
+++ b/package.json
@@ -18,20 +18,13 @@
   },
   "homepage": "https://github.com/zazuko/rdf-loaders-registry",
   "dependencies": {
-    "@rdfjs/data-model": "^1.1.1"
+    "@rdfjs/data-model": "^1.1.2"
   },
   "devDependencies": {
+    "@rdfjs/dataset": "^1.0.1",
     "@rdfjs/namespace": "^1.0.0",
-    "clownface": "^0.10.0",
-    "expect": "^24.1.0",
-    "jest": "^24.1.0",
-    "rdf-ext": "^1.2.2",
-    "standard": "^12.0.1"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-      "*.js"
-    ]
+    "clownface": "^0.12.0",
+    "jest": "^24.9.0",
+    "standard": "^14.3.1"
   }
 }


### PR DESCRIPTION
This PR changes the interface of the loader to the named argument interface, just like in the [Clownface PR](https://github.com/rdf-ext/clownface/pull/16). The `.load` method of the registry used already that interface. This makes it also more consistent inside the package.

It also changes the code to no longer rely on Clownface methods in the named arguments. That opens the interface for any object which has a `term` and `dataset` property.

The options forwarded to the loader are no longer hard coded. Only the `loaderRegistry` property is added. The hard coded list was derived from the pipeline projects and is maybe to specific for that use case.