### PR TITLE
feat!: use undefined as not loaded value

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class LoaderRegistry {
     const loader = this.loader(node)
 
     if (!loader) {
-      return null
+      return undefined
     }
 
     return loader(node, { ...options, loaderRegistry: this })

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -130,7 +130,7 @@ describe('LoaderRegistry', () => {
       expect(result).toBe('success')
     })
 
-    test('should return null if node loader is not found', () => {
+    test('should return undefined if node loader is not found', () => {
       // given
       const loader = () => 'success'
       registry.registerNodeLoader('http://example.com/code/script', loader)
@@ -145,10 +145,10 @@ describe('LoaderRegistry', () => {
       const result = registry.load(node)
 
       // then
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
     })
 
-    test('should return null if literal loader is not found', () => {
+    test('should return undefined if literal loader is not found', () => {
       // given
       const loader = () => 'success'
       registry.registerNodeLoader('http://example.com/code/script', loader)
@@ -160,7 +160,7 @@ describe('LoaderRegistry', () => {
       const result = registry.load(node)
 
       // then
-      expect(result).toBeNull()
+      expect(result).toBeUndefined()
     })
 
     test('loader is called with node argument', () => {


### PR DESCRIPTION
A loader may return `null`, which could not be distinguished from no loader found at the moment. This PR changes the value for no loader found to `undefined`. That behavior should match better for the two different use cases.